### PR TITLE
Fixed unescaping with invalid json

### DIFF
--- a/equal.go
+++ b/equal.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"math"
 	"strconv"
 
@@ -136,12 +137,11 @@ func utf8MixedUnescaped(b []byte) []byte {
 		return bytesEmpty
 	}
 
-	var v interface{}
-	json.Unmarshal(b, &v)
-
-	res, err := json.Marshal(v)
+	unescaped, err := jsonparser.Unescape(b, nil)
 	if err != nil {
-		res = b
+		fmt.Printf("Failed to unescape: %v", err)
+		return b
 	}
-	return res
+
+	return unescaped
 }


### PR DESCRIPTION
Old implementation ignored err from json.Unmarshal. When response contained invalid json it returned empty slice. Changed to jsonparser.Unescape that actually does unescaping and doesn't check json validity